### PR TITLE
fix: anchor basepath対応でhref関数を適用

### DIFF
--- a/src/components/decoratives/Links/SocialLink/internals/commons/IconLinkBase.astro
+++ b/src/components/decoratives/Links/SocialLink/internals/commons/IconLinkBase.astro
@@ -2,6 +2,7 @@
 import { cva } from "@styles/css";
 import type { HTMLAttributes } from "astro/types";
 import type { SocialLinkVariant } from "../../type";
+
 export interface Props extends HTMLAttributes<"a"> {
   /**
    *

--- a/src/components/domains/article/ArticleList/ArticleList.astro
+++ b/src/components/domains/article/ArticleList/ArticleList.astro
@@ -1,6 +1,7 @@
 ---
 import LetterLink from "@components/domains/article/LetterLink/LetterLink.astro";
 import type { Article } from "@content/articles";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 import type { HTMLAttributes } from "astro/types";
 
@@ -84,7 +85,7 @@ const itemStyle = css({});
                     >
                       <LetterLink
                         title={title}
-                        href={`/articles/${id}`}
+                        href={href(`/articles/${id}`)}
                         publishedAt={new Date(publishedAt)}
                         thumbnail={thumbnail}
                         thumbnailDisplayAlt={thumbnailLabel ?? ""}

--- a/src/components/domains/avatar/DecorativeAvatarLink/DecorativeAvatarLink.astro
+++ b/src/components/domains/avatar/DecorativeAvatarLink/DecorativeAvatarLink.astro
@@ -2,6 +2,7 @@
 import DecorativeAvatar, {
   type Props as BaseProps,
 } from "@components/domains/avatar/DecorativeAvatar/DecorativeAvatar.astro";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 interface Props extends Omit<BaseProps, "nickname" | "width" | "height"> {
@@ -23,7 +24,7 @@ const rootStyle = css({
 
 <a
   class:list={[rootStyle, className]}
-  href={`/casts/${nickname}`}
+  href={href(`/casts/${nickname}`)}
   aria-label={`店員"${nickname}"の紹介ページ`}
 >
   <DecorativeAvatar {...avatarImageProps} />

--- a/src/components/domains/guideline/GuidelineLink/GuidelineLink.astro
+++ b/src/components/domains/guideline/GuidelineLink/GuidelineLink.astro
@@ -4,6 +4,7 @@ import { toWidths } from "@components/domains/avatar/images/common";
 import type { ColorThemeBase } from "@content/commons";
 import type { BallonPosition } from "@content/guidelines";
 import { PC_VIEWPORT_WIDTH, SP_MAX_WIDTH } from "@lib/browsers/breakpoint";
+import { href } from "@lib/utils/base-path";
 import { css, cva } from "@styles/css";
 import type { HTMLAttributes } from "astro/types";
 
@@ -145,7 +146,7 @@ const widths = toWidths(Math.max(pcWidth, spWidth));
 const sizes = `${Math.round((pcWidth / PC_VIEWPORT_WIDTH) * 100)}%, (max-width: ${SP_MAX_WIDTH}px) ${Math.round((spWidth / PC_VIEWPORT_WIDTH) * 100)}%`;
 ---
 
-<a class={linkStyle} href={`/guidelines/${title}`} {...props}>
+<a class={linkStyle} href={href(`/guidelines/${title}`)} {...props}>
   <figure class={figureStyle}>
     <CustomPicture
       width={pcWidth}

--- a/src/components/layouts/HeadMeta/internals/FaviconMeta.astro
+++ b/src/components/layouts/HeadMeta/internals/FaviconMeta.astro
@@ -1,4 +1,8 @@
-<link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96" />
-<link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
-<link rel="icon" type="image/ico" href="/icons/favicon.ico" />
-<link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" sizes="180x180" />
+---
+import { href } from "@lib/utils/base-path";
+---
+
+<link rel="icon" type="image/png" href={href("/icons/favicon-96x96.png")} sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href={href("/icons/favicon.svg")} />
+<link rel="icon" type="image/ico" href={href("/icons/favicon.ico")} />
+<link rel="apple-touch-icon" href={href("/icons/apple-touch-icon.png")} sizes="180x180" />

--- a/src/components/layouts/Header/internals/HeaderLogo.astro
+++ b/src/components/layouts/Header/internals/HeaderLogo.astro
@@ -1,7 +1,7 @@
 ---
 import Logo from "@components/decoratives/Vectors/Logo/Logo.astro";
-import { css, cva } from "@styles/css";
 import { href } from "@lib/utils/base-path";
+import { css, cva } from "@styles/css";
 
 interface Props {
   class?: string;

--- a/src/components/layouts/Header/internals/HeaderLogo.astro
+++ b/src/components/layouts/Header/internals/HeaderLogo.astro
@@ -1,6 +1,7 @@
 ---
 import Logo from "@components/decoratives/Vectors/Logo/Logo.astro";
 import { css, cva } from "@styles/css";
+import { href } from "@lib/utils/base-path";
 
 interface Props {
   class?: string;
@@ -56,7 +57,7 @@ const iconStyle = css({
 ---
 
 <a
-  href="/"
+  href={href("/")}
   class:list={[logoStyle, props.class]}
   aria-label="ロリっ子喫茶ぷぷりえのホームページへのリンク"
   {...props}

--- a/src/components/layouts/Header/internals/HeaderNav.astro
+++ b/src/components/layouts/Header/internals/HeaderNav.astro
@@ -1,5 +1,6 @@
 ---
 import { getMeta } from "@content/meta";
+import { href } from "@lib/utils/base-path";
 import { hash } from "@lib/utils/random";
 import { css } from "@styles/css";
 import HamburgerIconButton from "./HamburgerIconButton.astro";
@@ -95,16 +96,16 @@ const {
   <HeaderLogo class={logoStyle} />
   <ul>
     <li>
-      <HeaderNavItem label={homeTitle} path="/" />
+      <HeaderNavItem label={homeTitle} path={href("/")} />
     </li>
     <li>
-      <HeaderNavItem label={articlesTitle} path="/articles" />
+      <HeaderNavItem label={articlesTitle} path={href("/articles")} />
     </li>
     <li>
-      <HeaderNavItem label={castsTitle} path="/casts" />
+      <HeaderNavItem label={castsTitle} path={href("/casts")} />
     </li>
     <li>
-      <HeaderNavItem label={guidelinesTitle} path="/guidelines" />
+      <HeaderNavItem label={guidelinesTitle} path={href("/guidelines")} />
     </li>
   </ul>
   <script>

--- a/src/components/pages/articles/ArticleNavigation/ArticleNavigation.astro
+++ b/src/components/pages/articles/ArticleNavigation/ArticleNavigation.astro
@@ -1,6 +1,7 @@
 ---
 import DecorativeLink from "@components/decoratives/Links/DecorativeLink/DecorativeLink.astro";
 import { getMeta } from "@content/meta";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 const {
@@ -19,7 +20,7 @@ const navClass = css({
 ---
 
 <nav class={navClass} aria-label="記事ナビゲーション">
-  <DecorativeLink href="/articles" themeColor="ice">
+  <DecorativeLink href={href("/articles")} themeColor="ice">
     {backLinkLabel}
   </DecorativeLink>
 </nav>

--- a/src/components/pages/cast/CastNavigator/CastNavigator.astro
+++ b/src/components/pages/cast/CastNavigator/CastNavigator.astro
@@ -4,6 +4,7 @@ import DecorativeAvatarLink from "@components/domains/avatar/DecorativeAvatarLin
 import { getNextEntry, getPrevEntry } from "@content/casts";
 import type { ColorThemeBase } from "@content/commons";
 import { getMeta } from "@content/meta";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 interface Props {
@@ -92,7 +93,7 @@ const navItems = [prevCast.data, nextCast.data];
       ))
     }
   </ul>
-  <DecorativeLink themeColor={themeColor} href="/casts">
+  <DecorativeLink themeColor={themeColor} href={href("/casts")}>
     {backLinkLabel}
   </DecorativeLink>
 </nav>

--- a/src/components/pages/guidelines/GuidelineNavigation/GuidelineNavigation.astro
+++ b/src/components/pages/guidelines/GuidelineNavigation/GuidelineNavigation.astro
@@ -1,6 +1,7 @@
 ---
 import DecorativeLink from "@components/decoratives/Links/DecorativeLink/DecorativeLink.astro";
 import { getMeta } from "@content/meta";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 const {
@@ -19,7 +20,7 @@ const navClass = css({
 ---
 
 <nav class={navClass} aria-label="ガイドラインナビゲーション">
-  <DecorativeLink href="/guidelines" themeColor="ice">
+  <DecorativeLink href={href("/guidelines")} themeColor="ice">
     {backLinkLabel}
   </DecorativeLink>
 </nav>

--- a/src/components/pages/home/CastPickupSection/CastPickupSection.astro
+++ b/src/components/pages/home/CastPickupSection/CastPickupSection.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import DecorativeAvatarLink from "@components/domains/avatar/DecorativeAvatarLink/DecorativeAvatarLink.astro";
 import HomePickupSection from "@components/layouts/Sections/HomePickupSection/HomePickupSection.astro";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 const casts = await getCollection("casts");
@@ -92,7 +93,7 @@ const imageWrapStyle = css({
 <HomePickupSection
   title="店員さんピックアップ"
   themeColor="rose"
-  hrefViewMore="/casts"
+  hrefViewMore={href("/casts")}
 >
   <ul class={listStyle} data-shuffle="cast">
     {

--- a/src/components/pages/home/HeroSection/internals/OverlayPopText.astro
+++ b/src/components/pages/home/HeroSection/internals/OverlayPopText.astro
@@ -2,6 +2,7 @@
 import DecorativeLink from "@components/decoratives/Links/DecorativeLink/DecorativeLink.astro";
 import Icon from "@components/decoratives/Vectors/Icon/Icon.astro";
 import { getMeta } from "@content/meta";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 import { token } from "@styles/tokens";
 
@@ -137,7 +138,7 @@ const { guidelinesShortcut } = await getMeta();
             <DecorativeLink
               themeColor={themeColor}
               type="right"
-              href={`/guidelines/${title}`}
+              href={href(`/guidelines/${title}`)}
               class={linkStyle}
             >
               {title}

--- a/src/components/pages/home/NewsHeadlineSection/NewsHeadlineSection.astro
+++ b/src/components/pages/home/NewsHeadlineSection/NewsHeadlineSection.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import LetterLink from "@components/domains/article/LetterLink/LetterLink.astro";
 import HomePickupSection from "@components/layouts/Sections/HomePickupSection/HomePickupSection.astro";
+import { href } from "@lib/utils/base-path";
 import { css } from "@styles/css";
 
 const articles = await getCollection("articles");
@@ -42,7 +43,7 @@ const listItemStyle = css({
 
 <HomePickupSection
   title="おしらせ"
-  hrefViewMore="/articles"
+  hrefViewMore={href("/articles")}
   themeColor="matcha"
 >
   <ul class={listStyle}>
@@ -51,7 +52,7 @@ const listItemStyle = css({
         ({ id, data: { title, thumbnail, thumbnailLabel, publishedAt } }) => (
           <li class={listItemStyle}>
             <LetterLink
-              href={`/articles/${id}`}
+              href={href(`/articles/${id}`)}
               title={title}
               thumbnail={thumbnail}
               thumbnailDisplayAlt={thumbnailLabel ?? ""}

--- a/src/lib/utils/base-path.ts
+++ b/src/lib/utils/base-path.ts
@@ -1,0 +1,17 @@
+import { base } from "astro:config/client";
+
+/**
+ * ベースパスを考慮したURLを生成する
+ * @param path - 相対パス（先頭の'/'は任意）
+ * @returns ベースパスが考慮されたURL
+ */
+export function href(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  // baseが未定義、空文字、または"/"の場合はそのまま返す
+  if (!base || base === "/") {
+    return normalizedPath;
+  }
+
+  return `${base}${normalizedPath}`;
+}


### PR DESCRIPTION
各コンポーネントでハードコードされたパスをhref関数でラップして
ベースパス対応を実装。新しいbase-path.tsユーティリティを追加。

🤖 Generated with [Claude Code](https://claude.ai/code)