### PR TITLE
 fix: #30 スマホだと自己紹介の背景要素と文章要素がずれてしまう

### DIFF
--- a/src/components/pages/cast/CastProfileSection/CastProfileSection.astro
+++ b/src/components/pages/cast/CastProfileSection/CastProfileSection.astro
@@ -57,7 +57,7 @@ const rootStyle = css({
 
 const paperAdjustStyle = css({
   top: {
-    base: "[inherit]",
+    base: "4",
     _pc: "4",
   },
 });


### PR DESCRIPTION
## 📝 変更の概要
<!-- このPRで何を変更したかを簡潔に説明してください -->
スマホ画面だと自己紹介と紙がずれていたため、paperAdjustStyleを変更した

## 🎯 変更の目的
<!-- なぜこの変更が必要なのかを説明してください -->
- [x] バグ修正
- [ ] 新機能追加
- [ ] 既存機能の改善
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:


## 🔧 変更内容
<!-- 具体的に何を変更したかを箇条書きで記載してください -->
- paperAdjustStyleのbase(スマホとか)を継承をやめて4に変更した
```diff
const paperAdjustStyle = css({
  top: {
-    base: "[inherit]",
+    base: "4",
    _pc: "4",
  },
});
```


## 📱 動作確認
<!-- 以下の環境で動作確認を行ったかチェックしてください -->
### テスト環境
- [x] Chrome (PC)
- [ ] Safari (iOS)
- [ ] Chrome (Android)
- [ ] その他:

### 確認項目
- [x] 新しい機能が正常に動作する
- [x] 既存機能に影響がない
- [x] レスポンシブデザインが正しく表示される
- [x] エラーが発生しない


## 🧪 テスト
`random.test.ts`でエラーは出るが、今回の変更で関係はないため別のissueでそれは解決してほしい
<!-- テストに関する情報を記載してください -->
- [ ] 既存のテストがすべて通る (`yarn test`)
- [ ] 新しいテストを追加した
- [ ] 型チェックが通る (`yarn typecheck`)
- [ ] Lintエラーがない (`yarn biome`)


## 📷 スクリーンショット
<!-- 変更によってUIに影響がある場合は、スクリーンショットを貼り付けてください -->
### Before（変更前）
<img width="380" height="264" alt="スクリーンショット 2025-10-05 0 50 59" src="https://github.com/user-attachments/assets/de73c101-5b79-4228-8fc3-ccd588146ceb" />


### After（変更後）
<img width="385" height="242" alt="スクリーンショット 2025-10-05 0 51 14" src="https://github.com/user-attachments/assets/8a1f74bd-e08e-41b9-a8c8-49693371be45" />



## 🔗 関連Issue
<!-- 関連するIssueがあれば記載してください -->
Fixes #30 


## 📋 レビュワーへの注意点



## ✅ チェックリスト
<!-- PRを出す前に以下の項目を確認してください -->
- [x] コードが正常に動作することを確認した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが分かりやすい
- [x] 不要なファイルやコメントを削除した
- [x] 大きな変更の場合は事前に相談した