### PR TITLE
fix: #26 ビルドの画像変換処理を５０分クラスから１分に短縮し、かつ安定化させた。褒め給えよ。

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import isWsl from "is-wsl";
 import { purgeInlineCss } from "./scripts/cleanup/purge-inline-css.js";
 import { renameRemoteImages } from "./scripts/cleanup/rename-remote-images.js";
 import { ghostFile, videoMediaInfoPlugin } from "./scripts/rollup/index.js";
+import { imageProxy } from "./scripts/server/image-proxy/index.js";
 
 const IS_PRODUCTION = process.env["NODE_ENV"] === "production";
 
@@ -66,6 +67,7 @@ export default defineConfig(
     site: `https://${SITE_DOMAIN}`,
     base: SITE_BASE,
     publicDir: USE_MOCK ? "public-mock" : "public",
+    integrations: [imageProxy()],
     image: {
       service: {
         entrypoint: "./src/lib/services/custom-sharp.ts",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lightningcss": "^1.30.1",
     "media-codecs": "^2.0.2",
     "mediainfo.js": "^0.3.5",
+    "msw": "^2.11.5",
     "ohash": "^2.0.11",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",

--- a/scripts/server/image-proxy/index.ts
+++ b/scripts/server/image-proxy/index.ts
@@ -1,0 +1,71 @@
+import type { AstroIntegration } from "astro";
+import { defu } from "defu";
+import type { SetupServerApi } from "msw/node";
+import { createImageProxyServer } from "./server.js";
+import { defaultOption, type ImageProxyOptions } from "./type.js";
+
+/**
+ * Astro Integration [Image Proxy]
+ * 画像の取得先の API 側で, 本来キャッシュすべき画像であるにもかかわらず, Etag や Cache Control に関する Response Header が適切に付与されていないケースがある.
+ * この Integration は, 画像の取得先の API 側の Response Header をパッチすることで, 画像のキャッシュを有効にするためのものである.
+ */
+export function imageProxy(option: ImageProxyOptions = {}): AstroIntegration {
+  const fixedOption = defu(option, defaultOption);
+  let server: SetupServerApi | null = null;
+  return {
+    name: "image-proxy",
+    hooks: {
+      "astro:config:setup"(context) {
+        context.logger.info("Image Proxy integration loaded");
+      },
+      async "astro:server:setup"({ logger }) {
+        logger.info("Image Proxy server setup");
+        try {
+          server =
+            server ?? (await createImageProxyServer(fixedOption, logger));
+        } catch (error) {
+          logger.error(`Failed to create proxy server: ${error}`);
+          throw error;
+        }
+      },
+      async "astro:build:start"({ logger }) {
+        logger.info("Image Proxy server setup");
+        try {
+          server =
+            server ?? (await createImageProxyServer(fixedOption, logger));
+        } catch (error) {
+          logger.error(`Failed to create proxy server: ${error}`);
+          throw error;
+        }
+      },
+      async "astro:server:done"({ logger }) {
+        logger.info("Image Proxy server done");
+        if (!server) {
+          return;
+        }
+
+        try {
+          await server.close();
+          server = null;
+        } catch (error) {
+          logger.error(`Failed to close proxy server: ${error}`);
+          throw error;
+        }
+      },
+      async "astro:build:done"({ logger }) {
+        logger.info("Image Proxy server done");
+        if (!server) {
+          return;
+        }
+
+        try {
+          await server.close();
+          server = null;
+        } catch (error) {
+          logger.error(`Failed to close proxy server: ${error}`);
+          throw error;
+        }
+      },
+    },
+  };
+}

--- a/scripts/server/image-proxy/server.ts
+++ b/scripts/server/image-proxy/server.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import type { AstroIntegrationLogger } from "astro";
+import { bypass, HttpResponse, type HttpResponseResolver, http } from "msw";
+import { type SetupServerApi, setupServer } from "msw/node";
+import { ClientError, type FixedImageProxyOptions } from "./type.js";
+
+/**
+ * ETag を生成する
+ * @param url
+ * @param buffer
+ * @returns
+ */
+function generateETag(url: string): string {
+  return createHash("md5").update(url).digest("hex");
+}
+
+/**
+ * リトライ対象のエラー
+ */
+const RETRY_ERRORS = Object.freeze([
+  "fetch failed",
+  "The operation was aborted due to timeout",
+]);
+
+/**
+ * オブジェクトから nullish なキーを削除する
+ * @param record
+ * @returns
+ */
+function removeNullishKey<T>(
+  record: Record<string, T | undefined>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([_, value]) => value !== undefined),
+  ) as Record<string, T>;
+}
+
+/**
+ * 1年後の日時を UTC 文字列で取得する
+ * @returns
+ */
+function getOneYearLater(): string {
+  return new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();
+}
+
+/**
+ * Cache-Control がキャッシュを無効化しているかどうかを判定する
+ * @param cacheControl
+ * @returns
+ */
+function isCacheDisabled(cacheControl: string | undefined): boolean {
+  if (!cacheControl) return true;
+
+  // max-age=0, no-cache, no-store などキャッシュ無効化を検出
+  return (
+    cacheControl.includes("max-age=0") ||
+    cacheControl.includes("no-cache") ||
+    cacheControl.includes("no-store")
+  );
+}
+
+/**
+ * レスポンスヘッダーにパッチを適用する
+ * @param headers 元のヘッダー
+ * @param url リクエストURL
+ * @returns パッチ適用後のヘッダー
+ */
+function patchHeaders(
+  headers: Record<string, string>,
+  url: string,
+): Record<string, string> {
+  return removeNullishKey({
+    ...headers,
+
+    // PATCH: fix disabled Cache-Control
+    // NOTE: Cache-Control がない、またはキャッシュが無効化されている場合にキャッシュを有効化する
+    "cache-control": isCacheDisabled(headers["cache-control"])
+      ? "public, max-age=31536000, immutable"
+      : headers["cache-control"],
+
+    // PATCH: add ETag if not exists
+    // NOTE: astro では ETag が存在しない場合にキャッシュを利用しない. Contents 側の API では ResponseHeader に ETag が存在しない場合がある.
+    etag: headers["etag"] ?? generateETag(url),
+
+    // PATCH: set expires to 1 year later
+    // NOTE: astro では expires が Date.now よりも大きい場合にキャッシュを利用する. Contents 側の API ではリクエストした時点の日時が expires にセットされる場合がある.
+    expires: getOneYearLater(),
+  });
+}
+
+/**
+ * リクエストを処理する
+ * @param option
+ * @param logger
+ * @returns
+ */
+async function createHandleRequest(
+  { timeout, retry }: FixedImageProxyOptions,
+  logger: AstroIntegrationLogger,
+): Promise<HttpResponseResolver> {
+  return async ({ request }) => {
+    try {
+      const { url } = request;
+      if (!url) {
+        // Bypass
+        return;
+      }
+
+      const response = await (async () => {
+        const errors: unknown[] = [];
+        for (let i = 0; i < retry; i++) {
+          try {
+            // NOTE: MSW の bypass 関数は, この関数の外で呼び出すとなぜか bypass されない問題あり.
+            return await fetch(bypass(request), {
+              signal: AbortSignal.timeout(timeout),
+            });
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              RETRY_ERRORS.includes(error.message)
+            ) {
+              errors.push(error);
+              continue;
+            }
+            throw error;
+          }
+        }
+
+        throw new AggregateError(errors, `Fetch failed after ${retry} retries`);
+      })();
+
+      const headers = Object.fromEntries(response.headers.entries());
+      const raw = Buffer.from(await response.arrayBuffer());
+
+      const fixedHeaders = patchHeaders(headers, url);
+
+      return new HttpResponse(raw, {
+        status: 200,
+        headers: fixedHeaders,
+      });
+    } catch (error) {
+      if (error instanceof ClientError) {
+        logger.error(`Client error: ${error.message}`);
+        return new HttpResponse(error.message, {
+          status: error.statusCode,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      logger.error(
+        `Unknown error: ${error instanceof Error ? error.message : error}`,
+      );
+      if (error instanceof Error && "cause" in error) {
+        logger.error(`Cause: ${error.cause}`);
+      }
+      return new HttpResponse(
+        error instanceof Error ? error.message : "Unknown error",
+        {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        },
+      );
+    }
+  };
+}
+
+/**
+ * 画像レスポンスにパッチするために MSW のサーバーを作成し, Astro のビルド中のリクエストをインターセプトする
+ * @param option
+ * @param loggerr
+ * @returns
+ */
+export async function createImageProxyServer(
+  option: FixedImageProxyOptions,
+  logger: AstroIntegrationLogger,
+): Promise<SetupServerApi> {
+  const server = setupServer(
+    http.get("https://*", await createHandleRequest(option, logger)),
+  );
+
+  server.events.on("unhandledException", (error) => {
+    logger.error(`Unhandled exception: ${error}`);
+  });
+
+  server.listen({ onUnhandledRequest: "bypass" });
+
+  return server;
+}

--- a/scripts/server/image-proxy/type.ts
+++ b/scripts/server/image-proxy/type.ts
@@ -1,0 +1,51 @@
+/**
+ * Astro Integration [Image Proxy] のオプション
+ */
+export interface ImageProxyOptions {
+  /**
+   * @default 3
+   */
+  retry?: number;
+
+  /**
+   * @default 30000
+   */
+  timeout?: number;
+}
+
+/**
+ * Astro Integration [Image Proxy] のオプションを固定化したもの (内部利用用)
+ */
+export type FixedImageProxyOptions = Required<ImageProxyOptions>;
+
+/**
+ * デフォルトのリトライ回数
+ */
+const DEFAULT_RETRY = 3;
+
+/**
+ * デフォルトのタイムアウト時間
+ */
+const DEFAULT_TIMEOUT = 30000;
+
+/**
+ * デフォルトのオプション
+ */
+export const defaultOption = Object.freeze({
+  retry: DEFAULT_RETRY,
+  timeout: DEFAULT_TIMEOUT,
+} satisfies Required<ImageProxyOptions>);
+
+/**
+ * 処理中に自明なエラーが発生している場合に投げるエラー.
+ * レスポンスで 400 系のステータスを返すべきかどうかの判断として利用する.
+ */
+export class ClientError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClientError";
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,6 +799,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@inquirer/ansi@npm:1.0.0"
+  checksum: 10c0/bac070de6b03dac71b31623d3e8911162856af18d731f899a71c13ffe371daa9a0cff941fed533b89d7e088e8d08d087bd2f97d1777bc6fe6ff4841518ca5a26
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.0.0":
+  version: 5.1.18
+  resolution: "@inquirer/confirm@npm:5.1.18"
+  dependencies:
+    "@inquirer/core": "npm:^10.2.2"
+    "@inquirer/type": "npm:^3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e29b80ff4449e93460f362ee2b633a04e73ffccea56f2fceff4451f61344ea5dd371bcc94279787e30a8356ab2f37c273d074f8a4f0ce97ab5e4833dfd9366b3
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "@inquirer/core@npm:10.2.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.0"
+    "@inquirer/figures": "npm:^1.0.13"
+    "@inquirer/type": "npm:^3.0.8"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/5475e343f7e3687cbfe877068a63f672da5414a35c95235bb13cf1a49c1fb3853aeb644cf13df514118ea036c267e3e2082706e52b6e6c1a4fb09e9d1c2d8384
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "@inquirer/figures@npm:1.0.13"
+  checksum: 10c0/23700a4a0627963af5f51ef4108c338ae77bdd90393164b3fdc79a378586e1f5531259882b7084c690167bf5a36e83033e45aca0321570ba810890abe111014f
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@inquirer/type@npm:3.0.8"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/1171bffb9ea0018b12ec4f46a7b485f7e2a328e620e89f3b03f2be8c25889e5b9e62daca3ea10ed040a71d847066c4d9879dc1fea8aa5690ebbc968d3254a5ac
+  languageName: node
+  linkType: hard
+
 "@isaacs/balanced-match@npm:^4.0.1":
   version: 4.0.1
   resolution: "@isaacs/balanced-match@npm:4.0.1"
@@ -833,6 +895,20 @@ __metadata:
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
+"@mswjs/interceptors@npm:^0.39.1":
+  version: 0.39.7
+  resolution: "@mswjs/interceptors@npm:0.39.7"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/e5c5614d93d9bd486d76f0ca8c1c3369b0c1d5b168092267d7503d67148a0b1a640a3ae5844d9f4931b59c78a4db4cab51bfd25f3c04053b0c86650fa4440d09
   languageName: node
   linkType: hard
 
@@ -894,6 +970,30 @@ __metadata:
     css-tree: "npm:^3.1.0"
     nanoid: "npm:^5.1.5"
   checksum: 10c0/f7362dda4c29d08813926fc6ad89ddf857c1406b551c01f35a4de29bcfc27443e8fefa5a81d6ca79eeae21ba646b8f22a33cda687642c6016ff368d069971f9e
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
   languageName: node
   linkType: hard
 
@@ -1531,6 +1631,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/d077a761a0753b079bf8279b3993948030ca86ed9125437b9b29c1de40db9b2deb7fddc369f014b58861d450e8b8cc75f163aa29dc8cea81952efbfd859168cf
+  languageName: node
+  linkType: hard
+
+"@types/statuses@npm:^2.0.4":
+  version: 2.0.6
+  resolution: "@types/statuses@npm:2.0.6"
+  checksum: 10c0/dd88c220b0e2c6315686289525fd61472d2204d2e4bef4941acfb76bda01d3066f749ac74782aab5b537a45314fcd7d6261eefa40b6ec872691f5803adaa608d
   languageName: node
   linkType: hard
 
@@ -2305,6 +2412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^8.0.1":
   version: 8.0.1
   resolution: "cliui@npm:8.0.1"
@@ -2398,13 +2512,13 @@ __metadata:
   linkType: hard
 
 "cross-spawn@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
-  checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
   languageName: node
   linkType: hard
 
@@ -3058,6 +3172,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql@npm:^16.8.1":
+  version: 16.11.0
+  resolution: "graphql@npm:16.11.0"
+  checksum: 10c0/124da7860a2292e9acf2fed0c71fc0f6a9b9ca865d390d112bdd563c1f474357141501c12891f4164fe984315764736ad67f705219c62f7580681d431a85db88
+  languageName: node
+  linkType: hard
+
 "h3@npm:^1.15.4":
   version: 1.15.4
   resolution: "h3@npm:1.15.4"
@@ -3222,6 +3343,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"headers-polyfill@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "headers-polyfill@npm:4.0.3"
+  checksum: 10c0/53e85b2c6385f8d411945fb890c5369f1469ce8aa32a6e8d28196df38568148de640c81cf88cbc7c67767103dd9acba48f4f891982da63178fc6e34560022afe
+  languageName: node
+  linkType: hard
+
 "hookable@npm:5.5.3":
   version: 5.5.3
   resolution: "hookable@npm:5.5.3"
@@ -3381,6 +3509,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
+  languageName: node
+  linkType: hard
+
 "is-number@npm:^7.0.0":
   version: 7.0.0
   resolution: "is-number@npm:7.0.0"
@@ -3446,11 +3581,11 @@ __metadata:
   linkType: hard
 
 "jiti@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "jiti@npm:2.4.2"
+  version: 2.6.1
+  resolution: "jiti@npm:2.6.1"
   bin:
     jiti: lib/jiti-cli.mjs
-  checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  checksum: 10c0/79b2e96a8e623f66c1b703b98ec1b8be4500e1d217e09b09e343471bbb9c105381b83edbb979d01cef18318cc45ce6e153571b6c83122170eefa531c64b6789b
   languageName: node
   linkType: hard
 
@@ -4651,10 +4786,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msw@npm:^2.11.5":
+  version: 2.11.5
+  resolution: "msw@npm:2.11.5"
+  dependencies:
+    "@inquirer/confirm": "npm:^5.0.0"
+    "@mswjs/interceptors": "npm:^0.39.1"
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@types/statuses": "npm:^2.0.4"
+    cookie: "npm:^1.0.2"
+    graphql: "npm:^16.8.1"
+    headers-polyfill: "npm:^4.0.2"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    rettime: "npm:^0.7.0"
+    statuses: "npm:^2.0.2"
+    strict-event-emitter: "npm:^0.5.1"
+    tough-cookie: "npm:^6.0.0"
+    type-fest: "npm:^4.26.1"
+    until-async: "npm:^3.0.2"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10c0/6e7bf559e7da85996df063e5cdc1befea5ab253e6b49d9a7910952b76cc28a53f0ed3581e4deb15b05b282289337cae13abc6a75e8273b017e916ee003dfd15a
+  languageName: node
+  linkType: hard
+
 "muggle-string@npm:^0.4.1":
   version: 0.4.1
   resolution: "muggle-string@npm:0.4.1"
   checksum: 10c0/e914b63e24cd23f97e18376ec47e4ba3aa24365e4776212b666add2e47bb158003212980d732c49abf3719568900af7861873844a6e2d3a7ca7e86952c0e99e9
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
   languageName: node
   linkType: hard
 
@@ -4831,6 +5006,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^6.2.0":
   version: 6.2.0
   resolution: "p-limit@npm:6.2.0"
@@ -4945,6 +5127,13 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
@@ -5153,6 +5342,7 @@ __metadata:
     lightningcss: "npm:^1.30.1"
     media-codecs: "npm:^2.0.2"
     mediainfo.js: "npm:^0.3.5"
+    msw: "npm:^2.11.5"
     ohash: "npm:^2.0.11"
     rehype-stringify: "npm:^10.0.1"
     remark-gfm: "npm:^4.0.1"
@@ -5473,6 +5663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rettime@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "rettime@npm:0.7.0"
+  checksum: 10c0/1460539d49415c37e46884bf1db7a5da974b239c1bd6976e1cf076fad169067dc8f55cd2572aec504433162f3627b6d8123eea977d110476258045d620bd051b
+  languageName: node
+  linkType: hard
+
 "reusify@npm:^1.0.4":
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
@@ -5717,7 +5914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -5846,6 +6043,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^3.9.0":
   version: 3.9.0
   resolution: "std-env@npm:3.9.0"
@@ -5857,6 +6061,13 @@ __metadata:
   version: 2.0.0
   resolution: "stream-replace-string@npm:2.0.0"
   checksum: 10c0/6cdf6108c57a869c1282dece0728bd7a8e314855bee71992436460192cdf46b3c976451e1e114716af209b2bfefa0e7e4581ca0eebc330d9dfcde341a72d50af
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
   languageName: node
   linkType: hard
 
@@ -6016,6 +6227,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.0.17":
+  version: 7.0.17
+  resolution: "tldts-core@npm:7.0.17"
+  checksum: 10c0/39dd6f5852f241c88391dc462dd236fa8241309a76dbf2486afdba0f172358260b16b98c126d1d06e1d9ee9015d83448ed7c4e2885e5e5c06c368f6503bb6a97
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.0.17
+  resolution: "tldts@npm:7.0.17"
+  dependencies:
+    tldts-core: "npm:^7.0.17"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/0ef2a40058a11c27a5b310489009002e57cd0789c2cf383c04ecf808e1523d442d9d9688ac0337c64b261609478b7fd85ddcd692976c8f763747a5e1c7c1c451
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
@@ -6029,6 +6258,15 @@ __metadata:
   version: 3.0.1
   resolution: "totalist@npm:3.0.1"
   checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "tough-cookie@npm:6.0.0"
+  dependencies:
+    tldts: "npm:^7.0.5"
+  checksum: 10c0/7b17a461e9c2ac0d0bea13ab57b93b4346d0b8c00db174c963af1e46e4ea8d04148d2a55f2358fc857db0c0c65208a98e319d0c60693e32e0c559a9d9cf20cb5
   languageName: node
   linkType: hard
 
@@ -6108,7 +6346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.21.0":
+"type-fest@npm:^4.21.0, type-fest@npm:^4.26.1":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
@@ -6445,6 +6683,13 @@ __metadata:
     uploadthing:
       optional: true
   checksum: 10c0/e315a0888e349f9938356c0a699a2dff5d52cf57398fbbcb07062aaf3643baf47652982d85de6557acf5dcb3a28425cd3b2f05ce851732a6e9984d18238618eb
+  languageName: node
+  linkType: hard
+
+"until-async@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "until-async@npm:3.0.2"
+  checksum: 10c0/61c8b03895dbe18fe3d90316d0a1894e0c131ea4b1673f6ce78eed993d0bb81bbf4b7adf8477e9ff7725782a76767eed9d077561cfc9f89b4a1ebe61f7c9828e
   languageName: node
   linkType: hard
 
@@ -7047,6 +7292,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -7165,6 +7421,13 @@ __metadata:
   dependencies:
     yoctocolors: "npm:^2.1.1"
   checksum: 10c0/4c4527f68161334291355eae0ab9a8e1b988bd854eebd93697d9a88b008362d71ad9f24334a79e48aca6ba1c085e365cd2981ba5ddc0ea54cc3efd96f2d08714
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.2":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 問題
外部APIから取得する画像が毎回ダウンロードされ、ビルド時間が長くなっていた。
特にGoogle Driveの画像で以下の不適切なヘッダーが原因:
- `cache-control: private, max-age=0` (キャッシュ無効)
- `etag` なし
- `expires` がリクエスト時点の日時

## 解決策
MSWを使った画像プロキシを実装し、レスポンスヘッダーをパッチ:
- キャッシュが無効化されているCache-Controlを修正
- ETagがない場合はURLベースのMD5ハッシュを生成
- Expiresを1年後に設定

これによりAstroのビルドキャッシュが有効になり、2回目以降のビルドで画像が再利用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 変更の概要
<!-- このPRで何を変更したかを簡潔に説明してください -->


## 🎯 変更の目的
<!-- なぜこの変更が必要なのかを説明してください -->
- [ ] バグ修正
- [ ] 新機能追加
- [ ] 既存機能の改善
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:


## 🔧 変更内容
<!-- 具体的に何を変更したかを箇条書きで記載してください -->
-
-
-


## 📱 動作確認
<!-- 以下の環境で動作確認を行ったかチェックしてください -->
### テスト環境
- [ ] Chrome (PC)
- [ ] Safari (iOS)
- [ ] Chrome (Android)
- [ ] その他:

### 確認項目
- [ ] 新しい機能が正常に動作する
- [ ] 既存機能に影響がない
- [ ] レスポンシブデザインが正しく表示される
- [ ] エラーが発生しない


## 🧪 テスト
<!-- テストに関する情報を記載してください -->
- [ ] 既存のテストがすべて通る (`yarn test`)
- [ ] 新しいテストを追加した
- [ ] 型チェックが通る (`yarn typecheck`)
- [ ] Lintエラーがない (`yarn biome`)


## 📷 スクリーンショット
<!-- 変更によってUIに影響がある場合は、スクリーンショットを貼り付けてください -->
### Before（変更前）


### After（変更後）



## 🔗 関連Issue
<!-- 関連するIssueがあれば記載してください -->
Fixes #<!-- Issue番号 -->


## 📋 レビュワーへの注意点
<!-- レビュワーに特に確認してほしい点があれば記載してください -->
-
-


## ✅ チェックリスト
<!-- PRを出す前に以下の項目を確認してください -->
- [ ] コードが正常に動作することを確認した
- [ ] 適切なブランチ名を使用している
- [ ] コミットメッセージが分かりやすい
- [ ] 不要なファイルやコメントを削除した
- [ ] 大きな変更の場合は事前に相談した