### PR TITLE
fix: #102 JSON-LD に含まれる画像URLを正確な URL に変更

### DIFF
--- a/src/components/layouts/HeadMeta/internals/OgpMeta.astro
+++ b/src/components/layouts/HeadMeta/internals/OgpMeta.astro
@@ -1,5 +1,4 @@
 ---
-import { getOgpImage } from "@lib/utils/image";
 import OgpArticleMeta from "./ogp/OgpArticleMeta.astro";
 import OgpProfileMeta from "./ogp/OgpProfileMeta.astro";
 import type { OGPMetadata } from "./ogpType";
@@ -8,35 +7,6 @@ type Props = OGPMetadata;
 
 const props = Astro.props;
 const siteUrl = Astro.url.href;
-
-interface OgpImageResult {
-  url: string;
-  width: number;
-  height: number;
-  type: "image/webp" | "image/png" | "image/jpeg" | "image/gif";
-}
-
-async function toOgpImage(
-  imageURL: string | ImageMetadata | undefined,
-): Promise<OgpImageResult | undefined> {
-  if (!imageURL) return undefined;
-
-  const image = await getOgpImage(imageURL);
-
-  // OGP 画像は絶対 URL である必要がある (特に X のクローラー用)
-  if (!Astro.site) {
-    throw new Error(
-      "Astro.site is not configured. Please set 'site' in astro.config",
-    );
-  }
-
-  return {
-    url: new URL(image.src, Astro.site).href,
-    width: image.attributes.width,
-    height: image.attributes.height,
-    type: `image/${image.options.format}` as OgpImageResult["type"],
-  };
-}
 
 // 単一値または配列を配列に統一
 function toArray<T>(value: T | T[] | undefined | null): T[] {
@@ -55,18 +25,8 @@ const {
   determiner,
   content,
 } = props;
-const images = await Promise.all(
-  toArray(props.image).map(async (image) => {
-    const ogpImageUrl = await toOgpImage(image.url);
-    return {
-      ...image,
-      url: ogpImageUrl?.url ?? "",
-      width: ogpImageUrl?.width ?? image.width,
-      height: ogpImageUrl?.height ?? image.height,
-      type: ogpImageUrl?.type ?? image.type,
-    };
-  }),
-);
+
+const images = toArray(props.image);
 const videos = toArray(props.video);
 const audios = toArray(props.audio);
 ---

--- a/src/components/layouts/HeadMeta/internals/SNSMeta.astro
+++ b/src/components/layouts/HeadMeta/internals/SNSMeta.astro
@@ -1,39 +1,9 @@
 ---
-import { getOgpImage } from "@lib/utils/image";
-import type { ImageMetadata } from "astro";
 import type { SNSMetadata } from "./snsType";
 
 interface Props extends SNSMetadata {}
 
 const { twitter } = Astro.props;
-
-interface ImageResult {
-  url: string;
-  alt?: string;
-}
-
-// 画像URL と alt テキストを取得
-async function getImageInfo(
-  image: string | ImageMetadata | undefined,
-): Promise<ImageResult | undefined> {
-  if (!image) return undefined;
-
-  const ogpImage = await getOgpImage(image);
-
-  // Twitter画像は絶対URLである必要がある
-  if (!Astro.site) {
-    throw new Error(
-      "Astro.site is not configured. Please set 'site' in astro.config",
-    );
-  }
-
-  const url = new URL(ogpImage.src, Astro.site).href;
-  const alt = ogpImage.attributes.alt;
-
-  return { url, alt };
-}
-
-const imageInfo = await getImageInfo(twitter.image);
 ---
 
 <meta name="twitter:card" content="summary_large_image" />
@@ -44,11 +14,11 @@ const imageInfo = await getImageInfo(twitter.image);
   )
 }
 {
-  imageInfo && (
+  twitter.image && (
     <>
-      <meta name="twitter:image" content={imageInfo.url} />
-      {imageInfo.alt && (
-        <meta name="twitter:image:alt" content={imageInfo.alt} />
+      <meta name="twitter:image" content={twitter.image} />
+      {twitter.imageAlt && (
+        <meta name="twitter:image:alt" content={twitter.imageAlt} />
       )}
     </>
   )

--- a/src/components/layouts/HeadMeta/internals/ogpType.ts
+++ b/src/components/layouts/HeadMeta/internals/ogpType.ts
@@ -13,7 +13,7 @@ type DateValue = string | Date;
 /** イメージメタデータ */
 export interface OGPImage {
   /** イメージの URL */
-  url: string | ImageMetadata;
+  url: string;
   /** セキュアな URL（HTTPS）*/
   secureUrl?: string;
   /** イメージの MIME タイプ */

--- a/src/components/layouts/HeadMeta/internals/snsType.ts
+++ b/src/components/layouts/HeadMeta/internals/snsType.ts
@@ -1,5 +1,3 @@
-import type { ImageMetadata } from "astro";
-
 /**
  *
  */
@@ -25,5 +23,8 @@ export interface TwitterMetadata {
   description?: string;
 
   /** ページを表すイメージ */
-  image?: string | ImageMetadata;
+  image?: string;
+
+  /** ページを表すイメージの alt テキスト */
+  imageAlt?: string;
 }

--- a/src/components/layouts/HeadMeta/types.ts
+++ b/src/components/layouts/HeadMeta/types.ts
@@ -1,5 +1,5 @@
 import type { ColorThemeBase } from "@content/commons";
-import type { OGPImage, OGPMetadata } from "./internals/ogpType";
+import type { OGPMetadata } from "./internals/ogpType";
 import type { Props as PolyfillProps } from "./internals/Polyfill.astro";
 import type { SNSMetadata } from "./internals/snsType";
 
@@ -37,17 +37,11 @@ export interface DescriptionMetaProps {
  * OGP メタデータのプロパティ（ページから指定する型）
  * width, height, type は自動計算されるため指定不要
  */
-export type OGPImageProps = Omit<OGPImage, "width" | "height" | "type">;
 
 /**
  * OGP プロパティ（url は Layout で追加されるため除外）
  */
-export interface OGPProps extends Omit<OGPMetadata, "url" | "image"> {
-  /**
-   * イメージ（width, height, type は自動計算）
-   */
-  image?: OGPImageProps | OGPImageProps[];
-}
+export interface OGPProps extends Omit<OGPMetadata, "url"> {}
 
 /**
  * SNS プロパティ

--- a/src/pages/articles/[id]/index.astro
+++ b/src/pages/articles/[id]/index.astro
@@ -1,10 +1,12 @@
 ---
 import { getCollection, getEntry } from "astro:content";
 import PageHeading from "@components/decoratives/Headings/PageHeading.astro";
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import ArticleContentSection from "@components/pages/articles/ArticleContentSection/ArticleContentSection.astro";
 import ArticleNavigation from "@components/pages/articles/ArticleNavigation/ArticleNavigation.astro";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { replaceByMap } from "@lib/utils/string";
 import { toAbsoluteUrl } from "@lib/utils/url";
 import { css } from "@styles/css";
@@ -59,6 +61,8 @@ const pageKeywords = [
   ...keywords.map((k) => replaceByMap(k, article)),
   ...articleKeywords,
 ];
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -71,7 +75,10 @@ const pageKeywords = [
     title: pageTitle,
     type: "article",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
     content: {
       article: {
@@ -83,7 +90,8 @@ const pageKeywords = [
     twitter: {
       title: pageTitle,
       description: pageDescription,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={[
@@ -92,7 +100,7 @@ const pageKeywords = [
       "@type": "Article",
       headline: pageTitle,
       description: pageDescription,
-      image: thumbnail,
+      image: toAbsoluteUrl(ogpImage.src, Astro.site),
       datePublished: new Date(publishedAt).toISOString(),
       url: Astro.url.href,
     },

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -3,9 +3,11 @@ import { getCollection } from "astro:content";
 import PageHeading from "@components/decoratives/Headings/PageHeading.astro";
 import ArticleDateShortcut from "@components/domains/article/ArticleDateShortcut/ArticleDateShortcut.astro";
 import ArticleList from "@components/domains/article/ArticleList/ArticleList.astro";
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
 import { sortByDesc, unique } from "@lib/utils/array";
+import { getOgpImage } from "@lib/utils/image";
 import { toAbsoluteUrl } from "@lib/utils/url";
 import { css } from "@styles/css";
 
@@ -51,6 +53,8 @@ const fitStyle = css({
     gap: "26",
   },
 });
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -63,14 +67,18 @@ const fitStyle = css({
     title,
     type: "website",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
   }}
   sns={{
     twitter: {
       title,
       description,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={{

--- a/src/pages/casts/[id]/index.astro
+++ b/src/pages/casts/[id]/index.astro
@@ -1,12 +1,13 @@
 ---
 import { getCollection, getEntry } from "astro:content";
-
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import CastImageSection from "@components/pages/cast/CastImageSection/CastImageSection.astro";
 import CastNavigator from "@components/pages/cast/CastNavigator/CastNavigator.astro";
 import CastProfileSection from "@components/pages/cast/CastProfileSection/CastProfileSection.astro";
 import type { SocialLinkType } from "@content/commons";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { replaceByMap } from "@lib/utils/string";
 import { toAbsoluteUrl } from "@lib/utils/url";
 
@@ -34,6 +35,8 @@ const defineLogos = [
   ...socialLinks.map((link) => link.type),
   "vrchat",
 ] as const satisfies SocialLinkType[];
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -48,7 +51,10 @@ const defineLogos = [
     title: replaceByMap(title, cast.profile),
     type: "profile",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
     content: {
       profile: {
@@ -60,7 +66,8 @@ const defineLogos = [
     twitter: {
       title: replaceByMap(title, cast.profile),
       description: replaceByMap(description, cast.profile),
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={[
@@ -68,7 +75,7 @@ const defineLogos = [
       "@context": "https://schema.org",
       "@type": "Person",
       name: replaceByMap(title, cast.profile),
-      image: thumbnail,
+      image: toAbsoluteUrl(ogpImage.src, Astro.site),
       url: Astro.url.href,
     },
     {

--- a/src/pages/casts/index.astro
+++ b/src/pages/casts/index.astro
@@ -1,9 +1,11 @@
 ---
 import { getCollection } from "astro:content";
 import PageHeading from "@components/decoratives/Headings/PageHeading.astro";
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import CastListNavigator from "@components/pages/cast/CastListNavigator/CastListNavigator.astro";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { toAbsoluteUrl } from "@lib/utils/url";
 
 const castCollection = await getCollection("casts");
@@ -13,6 +15,8 @@ const casts = castCollection.map((cast) => cast.data);
 const {
   casts: { title, description, keywords, thumbnail },
 } = await getMeta();
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -25,14 +29,18 @@ const {
     title,
     type: "website",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
   }}
   sns={{
     twitter: {
       title,
       description,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={{

--- a/src/pages/guidelines/[id]/index.astro
+++ b/src/pages/guidelines/[id]/index.astro
@@ -1,10 +1,12 @@
 ---
 import { getCollection, getEntry } from "astro:content";
 import PageHeading from "@components/decoratives/Headings/PageHeading.astro";
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import GuidelineContentSection from "@components/pages/guidelines/GuidelineContentSection/GuidelineContentSection.astro";
 import GuidelineNavigation from "@components/pages/guidelines/GuidelineNavigation/GuidelineNavigation.astro";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { replaceByMap } from "@lib/utils/string";
 import { toAbsoluteUrl } from "@lib/utils/url";
 import { css } from "@styles/css";
@@ -56,6 +58,8 @@ const pageKeywords = [
   ...keywords.map((k) => replaceByMap(k, guideline)),
   ...guideline.keywords,
 ];
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -68,14 +72,18 @@ const pageKeywords = [
     title: pageTitle,
     type: "article",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
   }}
   sns={{
     twitter: {
       title: pageTitle,
       description: pageDescription,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={[
@@ -84,7 +92,7 @@ const pageKeywords = [
       "@type": "WebPage",
       name: pageTitle,
       description: pageDescription,
-      image: thumbnail,
+      image: toAbsoluteUrl(ogpImage.src, Astro.site),
       url: Astro.url.href,
     },
     {

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -2,8 +2,10 @@
 import { getCollection } from "astro:content";
 import PageHeading from "@components/decoratives/Headings/PageHeading.astro";
 import GuidelineList from "@components/domains/guideline/GuidelineList/GuidelineList.astro";
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { toAbsoluteUrl } from "@lib/utils/url";
 
 const {
@@ -13,6 +15,8 @@ const {
 const guidelineCollection = await getCollection("guidelines");
 
 const guidelines = guidelineCollection.map((guideline) => guideline.data);
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -26,14 +30,18 @@ const guidelines = guidelineCollection.map((guideline) => guideline.data);
     title,
     type: "website",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
   }}
   sns={{
     twitter: {
       title,
       description,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={{

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,14 @@
 // biome-ignore lint/suspicious/noTsIgnore: ファイルが動的に作られるため
 // @ts-ignore ファイルが動的に作られるため
 import heroThumbnail from "@assets/videos/top.generated.thumbnail.webp";
+
+import type { OGPImage } from "@components/layouts/HeadMeta/internals/ogpType";
 import CastPickupSection from "@components/pages/home/CastPickupSection/CastPickupSection.astro";
 import HeroSection from "@components/pages/home/HeroSection/HeroSection.astro";
 import NewsHeadlineSection from "@components/pages/home/NewsHeadlineSection/NewsHeadlineSection.astro";
 import { getMeta } from "@content/meta";
 import Layout from "@layouts/Layout.astro";
+import { getOgpImage } from "@lib/utils/image";
 import { toAbsoluteUrl } from "@lib/utils/url";
 import { css } from "@styles/css";
 
@@ -20,6 +23,8 @@ const mainClass = css({
 const {
   home: { description, keywords, thumbnail },
 } = await getMeta();
+
+const ogpImage = await getOgpImage(thumbnail);
 ---
 
 <Layout
@@ -32,14 +37,18 @@ const {
     title: "ロリっ子喫茶ぷぷりえ",
     type: "website",
     image: {
-      url: thumbnail,
+      url: ogpImage.src,
+      width: ogpImage.attributes.width,
+      height: ogpImage.attributes.height,
+      type: `image/${ogpImage.options.format}` as OGPImage["type"],
     },
   }}
   sns={{
     twitter: {
       title: "ロリっ子喫茶ぷぷりえ",
       description,
-      image: thumbnail,
+      image: ogpImage.src,
+      imageAlt: ogpImage.attributes.alt,
     },
   }}
   jsonLd={[
@@ -48,7 +57,7 @@ const {
       "@type": "Organization",
       name: "ロリっ子喫茶ぷぷりえ",
       url: toAbsoluteUrl("/", Astro.site),
-      image: thumbnail,
+      image: toAbsoluteUrl(ogpImage.src, Astro.site),
       description,
     },
     {


### PR DESCRIPTION
JSON-LD に含まれる画像パスが違うパスになっていました。
これを実際の画像の絶対URL（https://.../_assets/...）に変換するように修正しました。

これにより、Googleクローラーなど外部のSEOクローラーが正しく
画像URLを認識できるようになります。

- 各ページで `getOgpImage()` で画像を正規化
- JSON-LD内の画像URLを `toAbsoluteUrl()` でラップして絶対URLに変換
- OgpMeta.astro と SNSMeta.astro の責任を整理（ページ側で事前処理）

修正対象ページ：
- index.astro（ホーム）
- articles/[id]/index.astro（記事詳細）
- articles/index.astro（記事一覧）
- casts/[id]/index.astro（キャスト詳細）
- casts/index.astro（キャスト一覧）
- guidelines/[id]/index.astro（ガイドライン詳細）
- guidelines/index.astro（ガイドライン一覧）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 変更の概要
<!-- このPRで何を変更したかを簡潔に説明してください -->


## 🎯 変更の目的
<!-- なぜこの変更が必要なのかを説明してください -->
- [ ] バグ修正
- [ ] 新機能追加
- [ ] 既存機能の改善
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:


## 🔧 変更内容
<!-- 具体的に何を変更したかを箇条書きで記載してください -->
-
-
-


## 📱 動作確認
<!-- 以下の環境で動作確認を行ったかチェックしてください -->
### テスト環境
- [ ] Chrome (PC)
- [ ] Safari (iOS)
- [ ] Chrome (Android)
- [ ] その他:

### 確認項目
- [ ] 新しい機能が正常に動作する
- [ ] 既存機能に影響がない
- [ ] レスポンシブデザインが正しく表示される
- [ ] エラーが発生しない


## 🧪 テスト
<!-- テストに関する情報を記載してください -->
- [ ] 既存のテストがすべて通る (`yarn test`)
- [ ] 新しいテストを追加した
- [ ] 型チェックが通る (`yarn typecheck`)
- [ ] Lintエラーがない (`yarn biome`)


## 📷 スクリーンショット
<!-- 変更によってUIに影響がある場合は、スクリーンショットを貼り付けてください -->
### Before（変更前）


### After（変更後）



## 🔗 関連Issue
<!-- 関連するIssueがあれば記載してください -->
Fixes #<!-- Issue番号 -->


## 📋 レビュワーへの注意点
<!-- レビュワーに特に確認してほしい点があれば記載してください -->
-
-


## ✅ チェックリスト
<!-- PRを出す前に以下の項目を確認してください -->
- [ ] コードが正常に動作することを確認した
- [ ] 適切なブランチ名を使用している
- [ ] コミットメッセージが分かりやすい
- [ ] 不要なファイルやコメントを削除した
- [ ] 大きな変更の場合は事前に相談した